### PR TITLE
fix: support CS2 "Armory" update

### DIFF
--- a/cvar-unhide-s2.vcxproj
+++ b/cvar-unhide-s2.vcxproj
@@ -13,9 +13,8 @@
   <ItemGroup>
     <ClCompile Include="cvars.cpp" />
     <ClCompile Include="main.cpp" />
-    <ClCompile Include="sdk\tier1\characterset.cpp" />
     <ClCompile Include="sdk\tier1\convar.cpp" />
-    <ClCompile Include="sdk\tier1\strtools.cpp" />
+    <ClCompile Include="sdk\tier1\generichash.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FE68CE13-526B-48C8-825C-F3BC64959AA4}</ProjectGuid>
@@ -27,13 +26,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/cvar-unhide-s2.vcxproj.filters
+++ b/cvar-unhide-s2.vcxproj.filters
@@ -27,10 +27,7 @@
     <ClCompile Include="sdk\tier1\convar.cpp">
       <Filter>Tier1 Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="sdk\tier1\strtools.cpp">
-      <Filter>Tier1 Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="sdk\tier1\characterset.cpp">
+    <ClCompile Include="sdk\tier1\generichash.cpp">
       <Filter>Tier1 Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
fix #8

Build against the last hl2sdk `cs2` branch to fix the issue.

[addons.zip](https://github.com/user-attachments/files/17251434/addons.zip)
